### PR TITLE
Clear leftover go WASM timers

### DIFF
--- a/main.js
+++ b/main.js
@@ -39,6 +39,12 @@ const inspect = (f, m = null) => {
     .catch(rej)
     .finally(() => {
       that.finish && that.finish()
+      // runtime.scheduleTimeoutEvent scheduled timeouts that didn't get
+      // runtime.clearTimeoutEvent'ed before we exit, we clear them manually
+      // here so they do not trigger with the runtime already exited
+      for (const fn of goruntime._scheduledTimeouts.values()) {
+        clearTimeout(fn)
+      }
       process.removeListener('exit', exitListener)
     });
   });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/zregvart/opa-inspect-js#readme",
   "scripts": {
-    "test": "node --experimental-vm-modules ./node_modules/.bin/jest"
+    "test": "node --experimental-vm-modules ./node_modules/.bin/jest --detectOpenHandles"
   },
   "files": [
     "*.js",


### PR DESCRIPTION
Seems that some scheduled timers are not cleared before the go WASM runtime exits, so the timer might trigger and expect a running runtime and fail with `Go program has already exited`.